### PR TITLE
Enable cross-platform integration tests on pull requests [AI-assisted]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,9 @@ jobs:
     name: Cross-Platform Integration Tests
     runs-on: ${{ matrix.os }}
     needs: [lint-and-type-check, test]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'pull_request'
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
## Summary

Resolves #15

This PR enables cross-platform integration tests (Windows, macOS, Linux) to run on pull requests in addition to pushes to the main branch. This allows catching platform-specific issues before merging.

## Changes

Updated `.github/workflows/ci.yml` line 194-196 to modify the `cross-platform-integration` job condition:

**Before:**
```yaml
if: github.event_name == 'push' && github.ref == 'refs/heads/main'
```

**After:**
```yaml
if: |
  (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
  github.event_name == 'pull_request'
```

## Benefits

- **Early detection**: Catch platform-specific bugs before merging to main
- **Higher confidence**: Ensure code quality across all supported platforms (Windows/macOS/Linux)
- **Cleaner history**: Fewer post-merge fixes and emergency patches

## Tradeoffs

- **CI time**: PRs will take ~10-15 minutes longer to complete
- **Resource usage**: Higher CI compute usage per PR
- **Cost**: May increase GitHub Actions minutes consumption

## Testing

- [x] YAML syntax validated
- [ ] Workflow will be tested when this PR is opened (cross-platform tests should run)

## Notes

This implements Option 1 from issue #15 (always run on PRs). If CI costs become a concern, we can switch to the label-based approach (Option 2) later.

[AI-assisted]