### PR TITLE
Removed unused aletheia_probe.validation.extract_issn_from_text from codebase

### DIFF
--- a/src/aletheia_probe/updater/__init__.py
+++ b/src/aletheia_probe/updater/__init__.py
@@ -4,7 +4,7 @@
 # Import dependencies used by sources and tests
 from ..cache import DataSourceManager
 from ..normalizer import input_normalizer
-from ..validation import extract_issn_from_text, validate_issn
+from ..validation import validate_issn
 from .core import DataSource, DataUpdater, get_update_source_registry
 from .sources import (
     AlgerianMinistrySource,
@@ -66,7 +66,6 @@ __all__ = [
     "clean_html_tags",
     "clean_publisher_name",
     "deduplicate_journals",
-    "extract_issn_from_text",
     "extract_year_from_text",
     "normalize_journal_name",
     "parse_date_string",

--- a/src/aletheia_probe/validation.py
+++ b/src/aletheia_probe/validation.py
@@ -131,35 +131,6 @@ def validate_doi(doi: str | None) -> bool:
     return bool(DOI_PATTERN.match(doi))
 
 
-def extract_issn_from_text(text: str) -> str | None:
-    """
-    Extract ISSN from text using regex pattern.
-
-    Args:
-        text: Text containing potential ISSN
-
-    Returns:
-        First ISSN found in normalized format, or None
-
-    Examples:
-        >>> extract_issn_from_text("ISSN: 1234-5678")
-        '1234-5678'
-        >>> extract_issn_from_text("No ISSN here")
-        None
-    """
-    if not text:
-        return None
-
-    # ISSN format: NNNN-NNNN or NNNNNNNN
-    issn_pattern = r"\b\d{4}-?\d{3}[\dXx]\b"
-    match = re.search(issn_pattern, text)
-
-    if match:
-        return normalize_issn(match.group())
-
-    return None
-
-
 def validate_email(email: str) -> str:
     """Validate email format.
 

--- a/tests/unit/test_updater_simple.py
+++ b/tests/unit/test_updater_simple.py
@@ -18,7 +18,7 @@ from aletheia_probe.updater.utils import (
     normalize_journal_name,
     parse_date_string,
 )
-from aletheia_probe.validation import extract_issn_from_text, validate_issn
+from aletheia_probe.validation import validate_issn
 
 
 class MockDataSource(DataSource):
@@ -170,17 +170,6 @@ class TestDataUpdater:
 
         # Test whitespace normalization
         assert normalize_journal_name("  Multiple   Spaces  ") == "multiple spaces"
-
-    def test_extract_issn_from_text(self):
-        """Test ISSN extraction from text."""
-
-        # Test various ISSN formats
-        assert extract_issn_from_text("ISSN: 1234-5678") == "1234-5678"
-        assert extract_issn_from_text("ISSN 1234-5678") == "1234-5678"
-        assert extract_issn_from_text("(ISSN: 1234-5678)") == "1234-5678"
-
-        # Test no ISSN found
-        assert extract_issn_from_text("No ISSN here") is None
 
     def test_clean_publisher_name(self):
         """Test publisher name cleaning."""


### PR DESCRIPTION
The function .extract_issn_from_text is unused in production code. Remove it.