### PR TITLE
Mark for abstract methods in updater/core.py as used.

### DIFF
--- a/src/aletheia_probe/updater/core.py
+++ b/src/aletheia_probe/updater/core.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from ..enums import AssessmentType
+from ..utils.dead_code import code_is_used
 
 
 class DataSource(ABC):
@@ -26,6 +27,7 @@ class DataSource(ABC):
     """
 
     @abstractmethod
+    @code_is_used
     def get_name(self) -> str:
         """Return the source name.
 
@@ -35,6 +37,7 @@ class DataSource(ABC):
         pass
 
     @abstractmethod
+    @code_is_used
     def get_list_type(self) -> AssessmentType:
         """Return the list type as AssessmentType enum member.
 
@@ -44,6 +47,7 @@ class DataSource(ABC):
         pass
 
     @abstractmethod
+    @code_is_used
     async def fetch_data(self) -> list[dict[str, Any]]:
         """Fetch and parse data from the source.
 
@@ -54,6 +58,7 @@ class DataSource(ABC):
         pass
 
     @abstractmethod
+    @code_is_used
     def should_update(self) -> bool:
         """Check if this source needs updating.
 


### PR DESCRIPTION
The following abstract methods are used, but the current dead code detector is not able to handle inherited abstract methods.

```
    DataSource.fetch_data
    DataSource.get_list_type
    DataSource.get_name
    DataSource.should_update
```

Therefore these are marked as used.