### PR TITLE
feat: add dedicated lookup command for venue normalization

### DIFF
--- a/src/aletheia_probe/cli.py
+++ b/src/aletheia_probe/cli.py
@@ -25,6 +25,7 @@ from .constants import DEFAULT_ACRONYM_CONFIDENCE_MIN
 from .dispatcher import query_dispatcher
 from .enums import AssessmentType
 from .logging_config import get_status_logger, setup_logging
+from .lookup import LookupResult, VenueLookupService
 from .models import AssessmentResult, CandidateAssessment, QueryInput, VenueType
 from .normalizer import are_conference_names_equivalent, input_normalizer
 from .output_formatter import output_formatter
@@ -375,6 +376,130 @@ def conference(
             confidence_min=confidence_min,
         )
     )
+
+
+@main.group(name="lookup")
+def lookup() -> None:
+    """Look up normalized venue candidates and known identifiers."""
+    pass
+
+
+@lookup.command(name="journal")
+@click.argument("journal_name")
+@click.option(
+    "--confidence-min",
+    default=DEFAULT_ACRONYM_CONFIDENCE_MIN,
+    show_default=True,
+    type=click.FloatRange(min=0.0, max=1.0),
+    help="Minimum acronym dataset confidence for variant candidates",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="text",
+    type=click.Choice(["text", "json"]),
+    help="Output format",
+)
+@handle_cli_errors
+def lookup_journal(
+    journal_name: str,
+    confidence_min: float,
+    output_format: str,
+) -> None:
+    """Look up normalized forms and identifiers for a journal input."""
+    _run_lookup_cli(journal_name, VenueType.JOURNAL, output_format, confidence_min)
+
+
+@lookup.command(name="conference")
+@click.argument("conference_name")
+@click.option(
+    "--confidence-min",
+    default=DEFAULT_ACRONYM_CONFIDENCE_MIN,
+    show_default=True,
+    type=click.FloatRange(min=0.0, max=1.0),
+    help="Minimum acronym dataset confidence for variant candidates",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="text",
+    type=click.Choice(["text", "json"]),
+    help="Output format",
+)
+@handle_cli_errors
+def lookup_conference(
+    conference_name: str,
+    confidence_min: float,
+    output_format: str,
+) -> None:
+    """Look up normalized forms and identifiers for a conference input."""
+    _run_lookup_cli(
+        conference_name, VenueType.CONFERENCE, output_format, confidence_min
+    )
+
+
+def _run_lookup_cli(
+    publication_name: str,
+    venue_type: VenueType,
+    output_format: str,
+    confidence_min: float,
+) -> None:
+    """Run lookup and print results in the requested format."""
+    service = VenueLookupService()
+    result = service.lookup(
+        publication_name, venue_type=venue_type, confidence_min=confidence_min
+    )
+
+    if output_format == "json":
+        print(json.dumps(result.to_dict(), indent=2))
+        return
+
+    print(_format_lookup_result_text(result))
+
+
+def _format_lookup_result_text(result: LookupResult) -> str:
+    """Format lookup results for human-readable CLI output."""
+    lines = [
+        f"Lookup: {result.raw_input}",
+        f"Venue Type: {result.venue_type.value}",
+        f"Primary Normalized Name: {result.normalized_name or '-'}",
+        f"ISSN Checksum Valid: {'yes' if result.issn_valid else 'no'}",
+        "",
+        "Normalized Names:",
+    ]
+
+    if result.normalized_names:
+        for name in result.normalized_names:
+            lines.append(f"- {name}")
+    else:
+        lines.append("- (none)")
+
+    lines.extend(["", "Identifiers:"])
+    lines.append(f"- input identifiers: {result.identifiers or {}}")
+    lines.append(f"- issns: {result.issns or []}")
+    lines.append(f"- eissns: {result.eissns or []}")
+
+    lines.extend(["", "Candidates:"])
+    if not result.candidates:
+        lines.append("- (none)")
+        return "\n".join(lines)
+
+    for candidate in result.candidates:
+        candidate_line = f"- {candidate.source}: {candidate.normalized_name}"
+        details: list[str] = []
+        if candidate.acronym:
+            details.append(f"acronym={candidate.acronym}")
+        if candidate.confidence is not None:
+            details.append(f"confidence={candidate.confidence:.2f}")
+        if candidate.issn:
+            details.append(f"issn={candidate.issn}")
+        if candidate.eissn:
+            details.append(f"eissn={candidate.eissn}")
+        if details:
+            candidate_line += f" ({', '.join(details)})"
+        lines.append(candidate_line)
+
+    return "\n".join(lines)
 
 
 @main.command()

--- a/src/aletheia_probe/lookup.py
+++ b/src/aletheia_probe/lookup.py
@@ -1,0 +1,406 @@
+# SPDX-License-Identifier: MIT
+"""Venue lookup service for normalization candidates and identifiers."""
+
+from dataclasses import asdict, dataclass, field
+
+from .cache import AcronymCache, JournalCache
+from .constants import DEFAULT_ACRONYM_CONFIDENCE_MIN
+from .models import QueryInput, VenueType
+from .normalizer import input_normalizer
+from .validation import validate_issn
+
+
+@dataclass
+class LookupCandidate:
+    """Single lookup candidate produced from a specific source."""
+
+    source: str
+    normalized_name: str
+    confidence: float | None = None
+    acronym: str | None = None
+    issn: str | None = None
+    eissn: str | None = None
+
+
+@dataclass
+class LookupResult:
+    """Structured lookup result for one venue input."""
+
+    raw_input: str
+    venue_type: VenueType
+    normalized_name: str | None
+    normalized_names: list[str] = field(default_factory=list)
+    aliases: list[str] = field(default_factory=list)
+    identifiers: dict[str, str] = field(default_factory=dict)
+    issn_valid: bool = False
+    issns: list[str] = field(default_factory=list)
+    eissns: list[str] = field(default_factory=list)
+    candidates: list[LookupCandidate] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable representation."""
+        return {
+            **asdict(self),
+            "venue_type": self.venue_type.value,
+            "candidates": [asdict(candidate) for candidate in self.candidates],
+        }
+
+
+class VenueLookupService:
+    """Build lookup candidates from local normalization and cache sources."""
+
+    def __init__(
+        self,
+        acronym_cache: AcronymCache | None = None,
+        journal_cache: JournalCache | None = None,
+    ) -> None:
+        self.acronym_cache = acronym_cache or AcronymCache()
+        self.journal_cache = journal_cache or JournalCache()
+
+    def lookup(
+        self,
+        raw_input: str,
+        venue_type: VenueType,
+        confidence_min: float = DEFAULT_ACRONYM_CONFIDENCE_MIN,
+    ) -> LookupResult:
+        """Resolve local normalization candidates for a venue string."""
+        base_query = input_normalizer.normalize(raw_input)
+        base_query.venue_type = venue_type
+        base_normalized_name = self._normalize_name_for_lookup(base_query.raw_input)
+
+        result = LookupResult(
+            raw_input=raw_input.strip(),
+            venue_type=venue_type,
+            normalized_name=base_normalized_name,
+            aliases=list(base_query.aliases),
+            identifiers=dict(base_query.identifiers),
+        )
+        is_standalone_acronym = input_normalizer._is_standalone_acronym(
+            base_query.raw_input.strip()
+        )
+
+        candidate_keys: set[tuple[str, str, str | None, str | None]] = set()
+        normalized_names: set[str] = set()
+        issns: set[str] = set()
+        eissns: set[str] = set()
+
+        self._add_candidate(
+            result=result,
+            candidate_keys=candidate_keys,
+            source="input",
+            normalized_name=base_normalized_name,
+        )
+
+        if base_normalized_name:
+            normalized_names.add(base_normalized_name)
+
+        for alias in base_query.aliases:
+            if alias:
+                normalized_alias = self._normalize_name_for_lookup(alias)
+                if normalized_alias:
+                    normalized_names.add(normalized_alias)
+
+        input_issn = base_query.identifiers.get("issn")
+        if input_issn:
+            issns.add(input_issn)
+            result.issn_valid = validate_issn(input_issn)
+
+        input_eissn = base_query.identifiers.get("eissn")
+        if input_eissn:
+            eissns.add(input_eissn)
+        self._add_identifier_reverse_lookup_candidates(
+            base_query,
+            result,
+            candidate_keys,
+            normalized_names,
+            issns,
+            eissns,
+        )
+
+        self._add_journal_cache_candidates(
+            normalized_name=(base_query.normalized_name or ""),
+            result=result,
+            candidate_keys=candidate_keys,
+            normalized_names=normalized_names,
+            issns=issns,
+            eissns=eissns,
+            skip_partial_search=is_standalone_acronym,
+        )
+        acronym_normalized_names = self._add_acronym_candidates(
+            base_query,
+            venue_type,
+            confidence_min,
+            result,
+            candidate_keys,
+            normalized_names,
+            issns,
+            eissns,
+        )
+        for resolved_name in sorted(acronym_normalized_names):
+            if resolved_name == base_normalized_name:
+                continue
+            self._add_journal_cache_candidates(
+                normalized_name=resolved_name,
+                result=result,
+                candidate_keys=candidate_keys,
+                normalized_names=normalized_names,
+                issns=issns,
+                eissns=eissns,
+                skip_partial_search=False,
+            )
+
+        result.normalized_names = sorted(normalized_names)
+        result.issns = sorted(issns)
+        result.eissns = sorted(eissns)
+        return result
+
+    def _add_identifier_reverse_lookup_candidates(
+        self,
+        base_query: QueryInput,
+        result: LookupResult,
+        candidate_keys: set[tuple[str, str, str | None, str | None]],
+        normalized_names: set[str],
+        issns: set[str],
+        eissns: set[str],
+    ) -> None:
+        """Reverse-resolve venue names from input ISSN/eISSN identifiers."""
+        query_identifiers = [
+            value for value in base_query.identifiers.values() if value
+        ]
+        for identifier in query_identifiers:
+            rows = self.journal_cache.search_journals(issn=identifier)
+            for row in rows[:5]:
+                display_name = str(row.get("display_name") or "").strip()
+                candidate_name = self._normalize_name_for_lookup(display_name)
+                if not candidate_name:
+                    continue
+
+                normalized_names.add(candidate_name)
+                row_issn = str(row.get("issn") or "").strip() or None
+                row_eissn = str(row.get("eissn") or "").strip() or None
+                if row_issn:
+                    issns.add(row_issn)
+                if row_eissn:
+                    eissns.add(row_eissn)
+
+                self._add_candidate(
+                    result=result,
+                    candidate_keys=candidate_keys,
+                    source="journal_cache_identifier_reverse",
+                    normalized_name=candidate_name,
+                    confidence=0.9,
+                    issn=row_issn,
+                    eissn=row_eissn,
+                )
+
+    def _add_journal_cache_candidates(
+        self,
+        normalized_name: str,
+        result: LookupResult,
+        candidate_keys: set[tuple[str, str, str | None, str | None]],
+        normalized_names: set[str],
+        issns: set[str],
+        eissns: set[str],
+        skip_partial_search: bool,
+    ) -> None:
+        """Add candidates from the journal cache."""
+        normalized_name = normalized_name.strip().lower()
+        if not normalized_name:
+            return
+
+        exact_ids = self.journal_cache.get_journal_identifiers_by_normalized_name(
+            normalized_name
+        )
+        if exact_ids:
+            issn = exact_ids.get("issn")
+            eissn = exact_ids.get("eissn")
+            if issn:
+                issns.add(issn)
+            if eissn:
+                eissns.add(eissn)
+            self._add_candidate(
+                result=result,
+                candidate_keys=candidate_keys,
+                source="journal_cache_exact",
+                normalized_name=normalized_name,
+                confidence=0.9,
+                issn=issn,
+                eissn=eissn,
+            )
+
+        if skip_partial_search:
+            return
+
+        rows = self.journal_cache.search_journals(normalized_name=normalized_name)
+        for row in rows[:5]:
+            display_name = str(row.get("display_name") or "").strip()
+            candidate_name = self._normalize_name_for_lookup(display_name)
+            if not candidate_name:
+                continue
+
+            normalized_names.add(candidate_name)
+            row_issn = str(row.get("issn") or "").strip() or None
+            row_eissn = str(row.get("eissn") or "").strip() or None
+            if row_issn:
+                issns.add(row_issn)
+            if row_eissn:
+                eissns.add(row_eissn)
+
+            self._add_candidate(
+                result=result,
+                candidate_keys=candidate_keys,
+                source="journal_cache_search",
+                normalized_name=candidate_name,
+                confidence=0.9,
+                issn=row_issn,
+                eissn=row_eissn,
+            )
+
+    def _add_acronym_candidates(
+        self,
+        base_query: QueryInput,
+        venue_type: VenueType,
+        confidence_min: float,
+        result: LookupResult,
+        candidate_keys: set[tuple[str, str, str | None, str | None]],
+        normalized_names: set[str],
+        issns: set[str],
+        eissns: set[str],
+    ) -> set[str]:
+        """Add candidates from acronym tables."""
+        raw_input = base_query.raw_input.strip()
+        entity_type = venue_type.value
+        resolved_normalized_names: set[str] = set()
+
+        if input_normalizer._is_standalone_acronym(raw_input):
+            expanded = self.acronym_cache.get_full_name_for_acronym(
+                raw_input,
+                entity_type,
+                min_confidence=confidence_min,
+            )
+            if expanded:
+                normalized_expanded = self._normalize_name_for_lookup(expanded)
+                if normalized_expanded:
+                    normalized_names.add(normalized_expanded)
+                    resolved_normalized_names.add(normalized_expanded)
+                    self._add_candidate(
+                        result=result,
+                        candidate_keys=candidate_keys,
+                        source="acronym_exact",
+                        normalized_name=normalized_expanded,
+                        confidence=confidence_min,
+                        acronym=raw_input,
+                    )
+
+        variant_inputs = [raw_input]
+        if base_query.normalized_name:
+            variant_inputs.append(base_query.normalized_name)
+        variant_inputs.extend(base_query.aliases[:10])
+
+        for variant_input in variant_inputs:
+            if not variant_input:
+                continue
+            variant_match = self.acronym_cache.get_variant_match(
+                variant_input,
+                entity_type,
+                min_confidence=confidence_min,
+            )
+            if not variant_match:
+                continue
+
+            canonical = str(variant_match.get("canonical") or "").strip()
+            acronym = str(variant_match.get("acronym") or "").strip() or None
+            confidence = float(variant_match.get("confidence_score") or 0.0)
+            canonical_normalized = self._normalize_name_for_lookup(canonical)
+            if not canonical_normalized:
+                continue
+
+            normalized_names.add(canonical_normalized)
+            resolved_normalized_names.add(canonical_normalized)
+            self._add_candidate(
+                result=result,
+                candidate_keys=candidate_keys,
+                source="acronym_variant",
+                normalized_name=canonical_normalized,
+                confidence=confidence,
+                acronym=acronym,
+            )
+
+            if acronym:
+                acronym_issns = self.acronym_cache.get_issns(
+                    acronym,
+                    entity_type,
+                    min_confidence=confidence_min,
+                )
+                for acronym_issn in acronym_issns:
+                    if acronym_issn:
+                        issns.add(acronym_issn)
+
+        input_issn = base_query.identifiers.get("issn")
+        if input_issn:
+            issn_match = self.acronym_cache.get_issn_match(
+                input_issn, min_confidence=0.0
+            )
+            if issn_match:
+                canonical = str(issn_match.get("canonical") or "").strip()
+                acronym = str(issn_match.get("acronym") or "").strip() or None
+                confidence = float(issn_match.get("confidence_score") or 0.0)
+                canonical_normalized = self._normalize_name_for_lookup(canonical)
+                if canonical_normalized:
+                    normalized_names.add(canonical_normalized)
+                    resolved_normalized_names.add(canonical_normalized)
+                    self._add_candidate(
+                        result=result,
+                        candidate_keys=candidate_keys,
+                        source="acronym_issn",
+                        normalized_name=canonical_normalized,
+                        confidence=confidence,
+                        acronym=acronym,
+                        issn=input_issn,
+                    )
+                    issns.add(input_issn)
+
+        # No local table currently provides explicit eISSN variants.
+        _ = eissns
+        return resolved_normalized_names
+
+    def _add_candidate(
+        self,
+        result: LookupResult,
+        candidate_keys: set[tuple[str, str, str | None, str | None]],
+        source: str,
+        normalized_name: str | None,
+        confidence: float | None = None,
+        acronym: str | None = None,
+        issn: str | None = None,
+        eissn: str | None = None,
+    ) -> None:
+        """Add a candidate with deduplication."""
+        cleaned_name = (normalized_name or "").strip().lower()
+        if not cleaned_name:
+            return
+
+        key = (source, cleaned_name, issn, eissn)
+        if key in candidate_keys:
+            return
+        candidate_keys.add(key)
+
+        result.candidates.append(
+            LookupCandidate(
+                source=source,
+                normalized_name=cleaned_name,
+                confidence=confidence,
+                acronym=acronym,
+                issn=issn,
+                eissn=eissn,
+            )
+        )
+
+    def _normalize_name_for_lookup(self, text: str | None) -> str:
+        """Normalize a name to lowercase canonical form for lookup output."""
+        if not text:
+            return ""
+        normalized = input_normalizer.normalize(text).normalized_name
+        if not normalized:
+            return ""
+        return normalized.strip().lower()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -13,6 +13,7 @@ from click.testing import CliRunner
 from aletheia_probe.cli import main
 from aletheia_probe.enums import AssessmentType
 from aletheia_probe.fallback_chain import QueryFallbackChain
+from aletheia_probe.lookup import LookupCandidate, LookupResult
 from aletheia_probe.models import (
     AssessmentResult,
     BackendResult,
@@ -219,6 +220,107 @@ class TestAssessCommand:
 
         assert result.exit_code != 0
         assert "invalid" in result.output.lower()
+
+
+class TestLookupCommand:
+    """Test cases for the lookup command group."""
+
+    def test_lookup_journal_invokes_runner(self, runner):
+        """Run lookup journal command with defaults."""
+        with patch("aletheia_probe.cli._run_lookup_cli") as mock_run_lookup:
+            result = runner.invoke(main, ["lookup", "journal", "Nature"])
+
+            assert result.exit_code == 0
+            mock_run_lookup.assert_called_once_with(
+                "Nature", VenueType.JOURNAL, "text", 0.8
+            )
+
+    def test_lookup_conference_json_invokes_runner(self, runner):
+        """Run lookup conference command with JSON output."""
+        with patch("aletheia_probe.cli._run_lookup_cli") as mock_run_lookup:
+            result = runner.invoke(
+                main,
+                ["lookup", "conference", "ICML", "--format", "json"],
+            )
+
+            assert result.exit_code == 0
+            mock_run_lookup.assert_called_once_with(
+                "ICML", VenueType.CONFERENCE, "json", 0.8
+            )
+
+    def test_lookup_journal_json_output(self, runner):
+        """Print structured JSON output for lookup results."""
+        lookup_result = LookupResult(
+            raw_input="Nature",
+            venue_type=VenueType.JOURNAL,
+            normalized_name="nature",
+            normalized_names=["nature"],
+            aliases=[],
+            identifiers={"issn": "0028-0836"},
+            issn_valid=True,
+            issns=["0028-0836"],
+            eissns=["1476-4687"],
+            candidates=[
+                LookupCandidate(
+                    source="input",
+                    normalized_name="nature",
+                    confidence=None,
+                )
+            ],
+        )
+
+        with patch("aletheia_probe.cli.VenueLookupService") as mock_service_class:
+            mock_service = Mock()
+            mock_service.lookup.return_value = lookup_result
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(
+                main, ["lookup", "journal", "Nature", "--format", "json"]
+            )
+
+            assert result.exit_code == 0
+            payload = json.loads(result.output)
+            assert payload["raw_input"] == "Nature"
+            assert payload["venue_type"] == "journal"
+            assert payload["issn_valid"] is True
+            assert payload["issns"] == ["0028-0836"]
+
+    def test_lookup_journal_text_output(self, runner):
+        """Print readable text output for lookup results."""
+        lookup_result = LookupResult(
+            raw_input="Nature",
+            venue_type=VenueType.JOURNAL,
+            normalized_name="nature",
+            normalized_names=["nature"],
+            aliases=[],
+            identifiers={"issn": "0028-0836"},
+            issn_valid=True,
+            issns=["0028-0836"],
+            eissns=["1476-4687"],
+            candidates=[
+                LookupCandidate(
+                    source="journal_cache_exact",
+                    normalized_name="nature",
+                    confidence=0.9,
+                    issn="0028-0836",
+                    eissn="1476-4687",
+                )
+            ],
+        )
+
+        with patch("aletheia_probe.cli.VenueLookupService") as mock_service_class:
+            mock_service = Mock()
+            mock_service.lookup.return_value = lookup_result
+            mock_service_class.return_value = mock_service
+
+            result = runner.invoke(main, ["lookup", "journal", "Nature"])
+
+            assert result.exit_code == 0
+            assert "Lookup: Nature" in result.output
+            assert "Venue Type: journal" in result.output
+            assert "Primary Normalized Name: nature" in result.output
+            assert "ISSN Checksum Valid: yes" in result.output
+            assert "journal_cache_exact: nature" in result.output
 
 
 class TestConfigCommand:

--- a/tests/unit/test_lookup.py
+++ b/tests/unit/test_lookup.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the venue lookup service."""
+
+from unittest.mock import Mock
+
+from aletheia_probe.lookup import VenueLookupService
+from aletheia_probe.models import VenueType
+
+
+class TestVenueLookupService:
+    """Test cases for local lookup behavior."""
+
+    def test_lookup_collects_cache_and_variant_candidates(self):
+        """Collect normalized names and identifiers from local cache sources."""
+        acronym_cache = Mock()
+        journal_cache = Mock()
+
+        journal_cache.get_journal_identifiers_by_normalized_name.return_value = {
+            "issn": "0028-0836",
+            "eissn": "1476-4687",
+        }
+        journal_cache.search_journals.return_value = [
+            {"display_name": "Nature", "issn": "0028-0836", "eissn": "1476-4687"}
+        ]
+
+        acronym_cache.get_full_name_for_acronym.return_value = None
+        acronym_cache.get_variant_match.return_value = {
+            "canonical": "nature",
+            "acronym": "NAT",
+            "confidence_score": 0.91,
+        }
+        acronym_cache.get_issns.return_value = ["0028-0836"]
+        acronym_cache.get_issn_match.return_value = {
+            "canonical": "nature",
+            "acronym": "NAT",
+            "confidence_score": 0.91,
+        }
+
+        service = VenueLookupService(
+            acronym_cache=acronym_cache,
+            journal_cache=journal_cache,
+        )
+        result = service.lookup("Nature 0028-0836", VenueType.JOURNAL)
+
+        assert result.issn_valid is True
+        assert "nature" in result.normalized_names
+        assert "0028-0836" in result.issns
+        assert "1476-4687" in result.eissns
+        assert any(c.source == "journal_cache_exact" for c in result.candidates)
+        assert any(c.source == "acronym_variant" for c in result.candidates)
+        assert any(c.source == "acronym_issn" for c in result.candidates)
+
+    def test_lookup_resolves_standalone_conference_acronym(self):
+        """Resolve standalone acronym candidates for conference lookup."""
+        acronym_cache = Mock()
+        journal_cache = Mock()
+
+        journal_cache.get_journal_identifiers_by_normalized_name.return_value = None
+        journal_cache.search_journals.return_value = []
+
+        acronym_cache.get_full_name_for_acronym.return_value = (
+            "international conference on machine learning"
+        )
+        acronym_cache.get_variant_match.return_value = None
+        acronym_cache.get_issns.return_value = []
+        acronym_cache.get_issn_match.return_value = None
+
+        service = VenueLookupService(
+            acronym_cache=acronym_cache,
+            journal_cache=journal_cache,
+        )
+        result = service.lookup("ICML", VenueType.CONFERENCE, confidence_min=0.8)
+
+        assert "international conference on machine learning" in result.normalized_names
+        assert any(c.source == "acronym_exact" for c in result.candidates)
+
+    def test_lookup_skips_broad_cache_search_for_standalone_acronym(self):
+        """Avoid broad LIKE-based cache matching for standalone acronym inputs."""
+        acronym_cache = Mock()
+        journal_cache = Mock()
+
+        journal_cache.get_journal_identifiers_by_normalized_name.side_effect = (
+            lambda name: (
+                {"issn": "0219-5259", "eissn": "1793-6802"}
+                if name == "advances in complex systems"
+                else None
+            )
+        )
+        journal_cache.search_journals.return_value = [
+            {"display_name": "acs applied materials and interfaces"}
+        ]
+
+        acronym_cache.get_full_name_for_acronym.return_value = (
+            "advances in complex systems"
+        )
+        acronym_cache.get_variant_match.return_value = None
+        acronym_cache.get_issns.return_value = []
+        acronym_cache.get_issn_match.return_value = None
+
+        service = VenueLookupService(
+            acronym_cache=acronym_cache,
+            journal_cache=journal_cache,
+        )
+        result = service.lookup("ACS", VenueType.JOURNAL)
+
+        searched_names = [
+            call.kwargs["normalized_name"]
+            for call in journal_cache.search_journals.call_args_list
+        ]
+        assert "acs" not in searched_names
+        assert "advances in complex systems" in result.normalized_names
+        assert "0219-5259" in result.issns
+        assert "1793-6802" in result.eissns
+
+    def test_lookup_reverse_identifier_resolves_name(self):
+        """Resolve a venue name from ISSN-only input via journal cache."""
+        acronym_cache = Mock()
+        journal_cache = Mock()
+
+        journal_cache.get_journal_identifiers_by_normalized_name.return_value = None
+        journal_cache.search_journals.side_effect = (
+            lambda normalized_name=None, issn=None: (
+                [
+                    {
+                        "display_name": "Advances in Complex Systems",
+                        "issn": "0219-5259",
+                        "eissn": "1793-6802",
+                    }
+                ]
+                if issn == "0219-5259"
+                else []
+            )
+        )
+
+        acronym_cache.get_full_name_for_acronym.return_value = None
+        acronym_cache.get_variant_match.return_value = None
+        acronym_cache.get_issns.return_value = []
+        acronym_cache.get_issn_match.return_value = None
+
+        service = VenueLookupService(
+            acronym_cache=acronym_cache,
+            journal_cache=journal_cache,
+        )
+        result = service.lookup("0219-5259", VenueType.JOURNAL)
+
+        assert result.issn_valid is True
+        assert "advances in complex systems" in result.normalized_names
+        assert "0219-5259" in result.issns
+        assert "1793-6802" in result.eissns
+        assert any(
+            c.source == "journal_cache_identifier_reverse" for c in result.candidates
+        )


### PR DESCRIPTION
## Summary
- add lookup journal|conference CLI commands for local normalization lookup
- introduce VenueLookupService to return normalized names, candidates, and identifiers
- support acronym-to-canonical enrichment without broad raw-acronym cache search
- add reverse ISSN/eISSN lookup to resolve normalized venue names from identifiers

## Motivation
This creates a standalone, testable normalization surface that can be reused by a future unified normalization phase without changing dispatcher behavior yet.

## Testing
- scripts/with-venv.sh pytest -q tests/unit/test_lookup.py tests/unit/test_cli.py -q
- full quality checks were run locally by the user and passed

## Checklist
- [x] quality checks pass
- [x] tests added/updated
- [x] docs/API behavior preserved for existing assessment commands

[AI-assisted]