### PR TITLE
chore: remove high-frequency detail debug logs from pattern matching

### DIFF
--- a/src/aletheia_probe/bibtex_parser.py
+++ b/src/aletheia_probe/bibtex_parser.py
@@ -1167,9 +1167,6 @@ class BibtexParser:
 
         for pattern in symposium_patterns:
             if re.search(pattern, venue_name_lower):
-                detail_logger.debug(
-                    f"Detected symposium pattern '{pattern}' in '{venue_name}'"
-                )
                 return VenueType.SYMPOSIUM
 
         # Workshop patterns (check before conference since workshops often contain "conference")
@@ -1184,9 +1181,6 @@ class BibtexParser:
 
         for pattern in workshop_patterns:
             if re.search(pattern, venue_name_lower):
-                detail_logger.debug(
-                    f"Detected workshop pattern '{pattern}' in '{venue_name}'"
-                )
                 return VenueType.WORKSHOP
 
         # Conference patterns (check after workshop/symposium)
@@ -1209,9 +1203,6 @@ class BibtexParser:
 
             for pattern in conference_patterns:
                 if re.search(pattern, venue_name_lower):
-                    detail_logger.debug(
-                        f"Detected conference pattern '{pattern}' in '{venue_name}'"
-                    )
                     return VenueType.CONFERENCE
 
             # If it's a conference-type entry but no conference patterns, might be proceedings
@@ -1242,9 +1233,6 @@ class BibtexParser:
         if entry_type_lower in ["article", "periodical", "suppperiodical"]:
             for pattern in journal_patterns:
                 if re.search(pattern, venue_name_lower):
-                    detail_logger.debug(
-                        f"Detected journal pattern '{pattern}' in '{venue_name}'"
-                    )
                     return VenueType.JOURNAL
 
             # Default to journal for article-type entries
@@ -1257,9 +1245,6 @@ class BibtexParser:
         # Check for other venue type patterns regardless of entry type
         for pattern in journal_patterns:
             if re.search(pattern, venue_name_lower):
-                detail_logger.debug(
-                    f"Detected journal pattern '{pattern}' in '{venue_name}'"
-                )
                 return VenueType.JOURNAL
 
         # If no patterns match, return UNKNOWN

--- a/src/aletheia_probe/cache/acronym_cache.py
+++ b/src/aletheia_probe/cache/acronym_cache.py
@@ -45,7 +45,6 @@ class AcronymCache(CacheBase):
         Returns:
             Canonical normalized name, or None if not found.
         """
-        detail_logger.debug(f"Looking up acronym '{acronym}' ({entity_type})")
         with self.get_connection_with_row_factory() as conn:
             cursor = conn.cursor()
             cursor.execute(
@@ -60,7 +59,6 @@ class AcronymCache(CacheBase):
                     f"Found canonical for '{acronym}' -> '{row['canonical']}'"
                 )
                 return str(row["canonical"])
-            detail_logger.debug(f"No entry found for '{acronym}' ({entity_type})")
             return None
 
     def get_variant_match(
@@ -78,7 +76,6 @@ class AcronymCache(CacheBase):
         Returns:
             Dict with keys ``canonical`` and ``acronym``, or None if no match.
         """
-        detail_logger.debug(f"Looking up variant '{variant}' ({entity_type})")
         with self.get_connection_with_row_factory() as conn:
             cursor = conn.cursor()
             cursor.execute(
@@ -106,9 +103,6 @@ class AcronymCache(CacheBase):
                     "acronym": acronym,
                     "confidence_score": float(row["confidence_score"]),
                 }
-            detail_logger.debug(
-                f"No variant match found for '{variant}' ({entity_type})"
-            )
             return None
 
     def get_canonical_for_variant(
@@ -201,7 +195,6 @@ class AcronymCache(CacheBase):
                     "acronym": acronym,
                     "confidence_score": float(row["confidence_score"]),
                 }
-            detail_logger.debug(f"No entry found for ISSN '{issn}'")
             return None
 
     def get_canonical_for_issn(


### PR DESCRIPTION
## Summary

- Remove per-match `detail_logger.debug` calls in `BibtexParser._detect_venue_type` (5 sites: symposium, workshop, conference, journal × 2 checks)
- Remove per-lookup `detail_logger.debug` calls in `AcronymCache` (`get_canonical`, `get_variant_match`, `get_canonical_for_issn`) for both hit and miss paths

## Motivation

These log lines fire on every entry processed, producing a high volume of low-signal output in the detail log. The remaining `detail_logger.info` lines on confirmed hits still provide useful tracing without the noise.

## Testing

No behaviour changes — existing test suite covers the affected code paths.

## Checklist

- [x] Quality checks pass
- [x] No new tests needed (pure log removal)
- [x] No functional changes